### PR TITLE
README: Fix example udev rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Add the following udev rule to `config.json`:
 ```
   "os": {
     "udevRules": {
-        "66": "ACTION==\"add\", SUBSYSTEMS==\"usb\", SUBSYSTEM==\"block\", ENV{ID_FS_USAGE}==\"filesystem\", RUN{program}+=\"/usr/bin/systemd-mount --no-block --automount=yes --collect $devnode\i /run/mount/ext"\n"
+      "66": "ACTION==\"add\", SUBSYSTEMS==\"usb\", SUBSYSTEM==\"block\", ENV{ID_FS_USAGE}==\"filesystem\", RUN{program}+=\"/usr/bin/systemd-mount --no-block --automount=yes --bind-device --options=fmask=111,dmask=000,noexec,nosuid,nodev,flush,sync --collect $devnode /run/mount/ext\"\n"
     }
-  }
+  },
 ```
 
 The device will be automatically mounted under `/run/mount/ext`.


### PR DESCRIPTION
Fix a syntax error and enhance the example udev rule:

* Use `--bind-device` so the automount is disabled when the device is removed
* Add mount options that make sense for removable devices, like sync, noexec, nosuid, fmask, dmask and flush.

Change-type: patch