### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,48 @@
-Automounting of an external USB disk
+## Automounting of an external drive
 ====================================
+
+In order to mount a USB or NVMe drive into containers, we first need to setup a `udev` rule in balenaOS. This rule needs to be added to the device `config.json` before flashing the device or manually via an ssh connection to the hostOS.
 
 Add the following udev rule to `config.json`:
 ```
   "os": {
     "udevRules": {
-      "66": "ACTION==\"add\", SUBSYSTEMS==\"usb\", SUBSYSTEM==\"block\", ENV{ID_FS_USAGE}==\"filesystem\", RUN{program}+=\"/usr/bin/systemd-mount --no-block --automount=yes --bind-device --options=fmask=111,dmask=000,noexec,nosuid,nodev,flush,sync --collect $devnode /run/mount/ext\"\n"
+      "66": "ACTION==\"add\", SUBSYSTEMS==\"usb\", SUBSYSTEM==\"block\", ENV{ID_FS_USAGE}==\"filesystem\", RUN{program}+=\"/usr/bin/systemd-mount --no-block --automount=yes --bind-device --options=noexec,nosuid,nodev,sync --collect $devnode /run/mount/ext\"\n"
+      "67": "ACTION==\"add\", SUBSYSTEMS==\"nvme\", KERNEL==\"nvme[0-9]n[0-9]\", ENV{ID_FS_USAGE}==\"filesystem\", RUN{program}+=\"/usr/bin/systemd-mount --no-block --automount=yes --bind-device --options=noexec,nosuid,nodev,sync --collect $devnode /run/mount/ext\"\n"
     }
   },
 ```
+Rule `66` is for USB and `67` is for NVMe drives, you only need to include the rule for the drive type you want to support.
 
-The device will be automatically mounted under `/run/mount/ext`.
+Once you have added the rules, reboot the device. Now anytime an external USB or NVMe drive is plugged in, the rule will automatically mount that drive under `/run/mount/ext`.
+
+## Make the drive available to containers
+
+Now in order to make the drive available to containers we need to create a volume that bind-mounts the location in `/run` to a named volume in our composition. To do this we add the following to our compose.yaml:
+```
+volumes:
+  test-volume:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind,rshared
+      device: /run/mount
+```
+
+This will create a named volume called `test-volume` that is mounted to the host `/run/mount/` directory. 
+
+**WARNING!!! :** It is not supported to mount anything outside of `/run/mount` for now as balenaOS makes no guarentees that those files and directories will exist in future versions.  
+
+Once we have the named volume, we can use it in any of our container services with the usual named volume syntax, like this:
+```
+services:
+  app1:
+    build:
+      context: ./app1
+    volumes:
+      - 'test-volume:/data'
+  app2:
+    image: my-image
+    volumes:
+      - 'test-volume:/app'
+```

--- a/app1/Dockerfile
+++ b/app1/Dockerfile
@@ -1,6 +1,0 @@
-FROM ubuntu:latest
-
-COPY entry.sh /bin/
-
-CMD /bin/entry.sh
-

--- a/app1/Dockerfile.template
+++ b/app1/Dockerfile.template
@@ -1,0 +1,8 @@
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian:latest
+
+RUN install_packages tree
+
+COPY entry.sh /bin/
+
+CMD /bin/entry.sh
+

--- a/app1/entry.sh
+++ b/app1/entry.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
 
-while true; do sleep 10; done
+# List everything in /data which should be mounted to `/run/mount/`
+echo "Everything in /data --> our external drive"
+tree /data
+# Idle forever to keep the container alive.
+balena-idle
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,11 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      o: bind
-      device: /run/mount/ext
+      o: bind,rshared
+      device: /run/mount
 services:
   app1:
     build:
       context: ./app1
     volumes:
       - 'test-volume:/data'
-


### PR DESCRIPTION
This PR:
- Improves the readme, including a rule for using this with NVMe drives.
- changes the named volume to bind-mount `/run/mount` rather than `/run/mount/ext` so that when a usb drive is not plugged the container won't crash loop.
- Adds minor changes to the parameters passed to the auto mount rule and bind mount inline with testing and support ticket where this was raised.
- 